### PR TITLE
Add optional multicall batch size

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ const outputFile = process.argv[3]
 const rpcUrl = process.env.FWC_RPC_URL
 
 const run = async () => {
-  const { chainId, prizePoolAddress, vaultAddress, userAddresses } = JSON.parse(fs.readFileSync(inputFile, 'utf8'))
+  const { chainId, multicallBatchSize, prizePoolAddress, vaultAddress, userAddresses } = JSON.parse(fs.readFileSync(inputFile, 'utf8'))
   
-  const allParams = Object.entries(await getAllParams(chainId, rpcUrl, prizePoolAddress, vaultAddress, userAddresses))
+  const allParams = Object.entries(await getAllParams(chainId, rpcUrl, prizePoolAddress, vaultAddress, userAddresses, { multicallBatchSize }))
   
   const scriptPath = join(rootDir, './sol/script/WinnerCalc.s.sol')
   const configPath = join(rootDir, './sol/foundry.toml')

--- a/utils/client.ts
+++ b/utils/client.ts
@@ -30,5 +30,5 @@ export const getClient = (chainId: number, rpcUrl: string, clientOptions?: { mul
       }
     }
   } 
-  return client;
+  return client
 }

--- a/utils/client.ts
+++ b/utils/client.ts
@@ -21,6 +21,14 @@ const chains: Record<number, Chain> = {
   421614: arbitrumSepolia
 }
 
-export const getClient = (chainId: number, rpcUrl: string) => {
-  return createPublicClient({ chain: chains[chainId], transport: http(rpcUrl) }) as PublicClient<HttpTransport>
+export const getClient = (chainId: number, rpcUrl: string, clientOptions?: { multicallBatchSize?: number }) => {
+  const client = createPublicClient({ chain: chains[chainId], transport: http(rpcUrl) }) as PublicClient<HttpTransport>
+  if (!!clientOptions?.multicallBatchSize) {
+    client.batch = {
+      multicall: {
+        batchSize: clientOptions?.multicallBatchSize
+      }
+    }
+  } 
+  return client;
 }

--- a/utils/params.ts
+++ b/utils/params.ts
@@ -4,10 +4,10 @@ import { getPrizePoolInfo, getTierInfo, getVaultPortion } from "./prizePool.js"
 import { getTwabs } from "./twab.js"
 import type { Address } from "viem"
 
-export const getAllParams = async (chainId: number, rpcUrl: string, prizePoolAddress: Address, vaultAddress: Address, userAddresses: Address[]) => {
+export const getAllParams = async (chainId: number, rpcUrl: string, prizePoolAddress: Address, vaultAddress: Address, userAddresses: Address[], options?: { multicallBatchSize?: number }) => {
   const params: { [tier: number]: `0x${string}` } = {}
 
-  const client = getClient(chainId, rpcUrl)
+  const client = getClient(chainId, rpcUrl, options)
 
   const prizePoolInfo = await getPrizePoolInfo(client, prizePoolAddress)
   const tierInfo = await getTierInfo(client, prizePoolAddress, prizePoolInfo.numTiers, prizePoolInfo.lastAwardedDrawId)


### PR DESCRIPTION
Adds an optional arg to the `input.json` file: `multicallBatchSize` and passes it to the viem client on creation.